### PR TITLE
Remove reference to stronghold-script

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,7 @@ Options:
     + `$ pip install stronghold`
     + `$ stronghold`
 
-2. Download and run the `stronghold-script.sh` shell script.
-    + `$ sudo ./stronghold-script.sh`
-
-3. Download the `stronghold` binary from Releases tab.
+2. Download the `stronghold` binary from Releases tab.
 
 
 **Configuration Options**


### PR DESCRIPTION
The script was removed in dc283b12.
Quoting @alichtman:
> If you run ‘stronghold -lockdown’, it accomplishes exactly the same thing. Basically, I wanted to minimize the number of changes I’d have to duplicate if I ever wanted to modify the script. One script is the way to go.